### PR TITLE
Fixes #1: Updates Mako template reset default value to account for None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ __pycache__
 .venv
 *.egg-info
 build
-generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .venv
 *.egg-info
+build
+generated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "systemrdl-compiler"
+    "systemrdl-compiler",
     "peakrdl",
     "mako",
 ]

--- a/simple8.rdl
+++ b/simple8.rdl
@@ -39,7 +39,7 @@ addrmap simple8 {
                 desc = "Field description";
                 hw   = rw;
                 sw   = rw;
-            } divlen[6] = 0x0;
+            } divlen[6]; // no default value
         } clkdiv ;
     } ;
 

--- a/src/peakrdl_sv/reg_top.sv.tpl
+++ b/src/peakrdl_sv/reg_top.sv.tpl
@@ -251,7 +251,7 @@ OnWriteWset
 OnReadNone
 </%def>\
 <%def name="reset_gen(field)" filter="trim">\
-${field.width}'d${field.reset if field.reset is not None else 0}
+${field.width}'d${field.reset or 0}
 </%def>\
 <%def name="sv_bitarray(field)" filter="trim">\
 % if field.width > 1:

--- a/src/peakrdl_sv/reg_top.sv.tpl
+++ b/src/peakrdl_sv/reg_top.sv.tpl
@@ -251,7 +251,7 @@ OnWriteWset
 OnReadNone
 </%def>\
 <%def name="reset_gen(field)" filter="trim">\
-${field.width}'d${field.reset}
+${field.width}'d${field.reset if field.reset is not None else 0}
 </%def>\
 <%def name="sv_bitarray(field)" filter="trim">\
 % if field.width > 1:


### PR DESCRIPTION
https://github.com/NuQuantum/peakrdl-sv/issues/1 Describes the issue. TL:DR, when a default value is not provided to a register field it causes the register template to be instanced with a ResetVal of `None`, yielding a syntax error in SV.

There were two options to fix this issue:

1) Update the `Field.reset()` property to check for `None` on the result of `self.get_property()`. 

2) Update the mako template to check for None when it reads the reset value via the call to `Field.reset()`

The second option was chosen as the `Field.reset()` property should simply return whatever the reset value is, even if its none! It's on the caller to validate what that function returns. i.e. `Field.reset()` shouldn't be opinionated.  