### PR TITLE
feat(NQ-3306): Only generate `reg2hw`/`hw2reg` structs if they aren't null

### DIFF
--- a/src/peakrdl_sv/node.py
+++ b/src/peakrdl_sv/node.py
@@ -157,6 +157,16 @@ class Register(Node):
         return self.regwidth > self.accesswidth
 
     @property
+    def is_reg2hw(self) -> bool:
+        """Returns True if the register will be present in the reg2hw struct."""
+        return self.needs_qe or self.needs_qre or self.has_hw_readable
+
+    @property
+    def is_hw2reg(self) -> bool:
+        """Returns True if the register will be present in the hw2reg struct."""
+        return self.has_hw_writable
+
+    @property
     def addressincr(self) -> int:
         """How many bytes each SW access addresses.
 
@@ -231,9 +241,19 @@ class AddressMap(Node):
         return registers
 
     @property
+    def has_hw2reg(self) -> bool:
+        """Returns True if any register has a hw2reg struct."""
+        return any([reg.is_hw2reg for reg in self.get_registers()])
+
+    @property
+    def has_reg2hw(self) -> bool:
+        """Returns True if any register has a reg2hw struct."""
+        return any([reg.is_reg2hw for reg in self.get_registers()])
+
+    @property
     def addrwidth(self) -> int:
         return (self.size - 1).bit_length()
 
     @property
     def accesswidth(self) -> int:
-        return min([reg.get_property("accesswidth") for reg in self.get_registers()])
+        return min([reg.accesswidth for reg in self.get_registers()])

--- a/src/peakrdl_sv/reg_pkg.sv.tpl
+++ b/src/peakrdl_sv/reg_pkg.sv.tpl
@@ -75,6 +75,8 @@ package ${lname}_reg_pkg;
 
   % endfor
 
+  ## Only create the reg2hw if there is atleast one register requiring q, qe or qre signals.
+  %if block.has_reg2hw:
   // Register -> HW
   typedef struct packed {
 <%
@@ -95,7 +97,10 @@ package ${lname}_reg_pkg;
     % endif
   % endfor
   } ${lname}_reg2hw_t;
+  % endif
 
+  ## Only create the hw2reg if there is atleast one register that is hw_writable.
+  % if block.has_hw2reg:
   // HW -> Register
   typedef struct packed {
 <%
@@ -116,6 +121,7 @@ package ${lname}_reg_pkg;
     % endif
   % endfor
   } ${lname}_hw2reg_t;
+  % endif
 
   // Register address offsets
   % for r in registers:

--- a/src/peakrdl_sv/reg_top.sv.tpl
+++ b/src/peakrdl_sv/reg_top.sv.tpl
@@ -66,9 +66,12 @@ module ${lblock}_reg_top
   output logic [DW-1:0] reg_rdata,
 
   // HW I/F
+  % if block.has_reg2hw:
   output ${lblock}_reg_pkg::${lblock}_reg2hw_t reg2hw, // Write
+  % endif
+  % if block.has_hw2reg:
   input  ${lblock}_reg_pkg::${lblock}_hw2reg_t hw2reg  // Read
-
+  % endif
 );
 
   // --------------------------------------------------------------------------------


### PR DESCRIPTION
For some register maps, there may be no hardware readable registers (in which case, no reg2hw), or no hardware writable registers (in which case, no hw2reg). In these cases those structs and ports should not be generated as they cause syntax errors.

This PR first checks if any of the conditions which causes a register to be instantiated are true (across all registers), to deduce which structs/ports are necessary.